### PR TITLE
Change Bower installation directory

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,3 @@
 {
-  "directory": "ext/lib"
+  "directory": "chrome/lib"
 }


### PR DESCRIPTION
Install the Bower packages directly inside the extension directory as opposed to in a separate one.
